### PR TITLE
Upgrading the version of transformers and fix the path

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ CUDA_VISIBLE_DEVICES=0 python ./extract_act/extracting_activations_qwen_jb.py
 
 To obtain the calibration activations (e.g., for Qwen2-VL), run the following commands:
 ```bash
-CUDA_VISIBLE_DEVICES=0 python ./extract_act/extracting_activations_qwen_ref.py
+CUDA_VISIBLE_DEVICES=0 python ./extract_ref/extracting_activations_qwen_ref.py
 ```
 
 ### Activations

--- a/requirements.txt
+++ b/requirements.txt
@@ -105,7 +105,7 @@ tokenizers==0.19.1
 torch==2.4.0
 torchvision==0.19.0
 tqdm==4.66.4
-transformers==4.42.4
+transformers @ git+https://github.com/huggingface/transformers@21fac7abba2a37fae86106f87fcf9974fd1e3830
 triton==3.0.0
 typer==0.12.3
 typing_extensions==4.12.2


### PR DESCRIPTION
This pull request updates the documentation to fix the path of a script in the instructions for extracting calibration activations for Qwen2-VL, and modify the version of transformers in ```requirements.txt```.

Documentation update:

* Corrected the script path in the example command from `./extract_act/extracting_activations_qwen_ref.py` to `./extract_ref/extracting_activations_qwen_ref.py` in the `README.md` file to ensure users run the correct script.

* Modify the Transformers version in `requirements.txt` resolved the `cannot import name ‘Qwen2VLForConditionalGeneration’ from ‘transformers’` error during Minigpt4 training.